### PR TITLE
Add save function tests

### DIFF
--- a/Main_1.py
+++ b/Main_1.py
@@ -3,6 +3,39 @@ from datetime import datetime
 import os
 
 
+def save_interrogatorio_to_txt(interrogatorio: dict, page: ft.Page):
+    """Save questionnaire data to a timestamped TXT file."""
+    try:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"interrogatorio_mtc_{timestamp}.txt"
+
+        if not os.path.exists("dados_interrogatorio"):
+            os.makedirs("dados_interrogatorio")
+
+        with open(f"dados_interrogatorio/{filename}", "w", encoding="utf-8") as f:
+            for section, content in interrogatorio.items():
+                f.write(f"\n{section}\n")
+                f.write("=" * 50 + "\n")
+                for key, value in content.items():
+                    if value:
+                        f.write(f"{key}: {value}\n")
+
+        page.snack_bar = ft.SnackBar(
+            ft.Text(f"Dados salvos com sucesso em {filename}"),
+            bgcolor=ft.colors.GREEN_400,
+        )
+        page.snack_bar.open = True
+        page.update()
+
+    except Exception as e:  # pragma: no cover - defensive
+        page.snack_bar = ft.SnackBar(
+            ft.Text(f"Erro ao salvar: {str(e)}"),
+            bgcolor=ft.colors.RED_400,
+        )
+        page.snack_bar.open = True
+        page.update()
+
+
 def main(page: ft.Page):
     page.title = "Interrogatório MTC"
     page.scroll = "adaptive"
@@ -33,35 +66,7 @@ def main(page: ft.Page):
 
     # Função para salvar em TXT
     def save_to_txt(e):
-        try:
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            filename = f"interrogatorio_mtc_{timestamp}.txt"
-
-            if not os.path.exists("dados_interrogatorio"):
-                os.makedirs("dados_interrogatorio")
-
-            with open(f"dados_interrogatorio/{filename}", "w", encoding="utf-8") as f:
-                for section, content in interrogatorio.items():
-                    f.write(f"\n{section}\n")
-                    f.write("=" * 50 + "\n")
-                    for key, value in content.items():
-                        if value:  # Só escreve se tiver valor
-                            f.write(f"{key}: {value}\n")
-
-            page.snack_bar = ft.SnackBar(
-                ft.Text(f"Dados salvos com sucesso em {filename}"),
-                bgcolor=ft.colors.GREEN_400
-            )
-            page.snack_bar.open = True
-            page.update()
-
-        except Exception as e:
-            page.snack_bar = ft.SnackBar(
-                ft.Text(f"Erro ao salvar: {str(e)}"),
-                bgcolor=ft.colors.RED_400
-            )
-            page.snack_bar.open = True
-            page.update()
+        save_interrogatorio_to_txt(interrogatorio, page)
 
     # Seção 1: Identificação
     def build_identificacao():
@@ -759,4 +764,6 @@ def main(page: ft.Page):
     )
 
 
-ft.app(target=main)
+
+if __name__ == "__main__":
+    ft.app(target=main)

--- a/tests/test_save_to_txt.py
+++ b/tests/test_save_to_txt.py
@@ -1,0 +1,83 @@
+import types
+from unittest import mock
+
+import sys
+import os
+import importlib
+
+dummy_ft = types.SimpleNamespace(
+    SnackBar=lambda *a, **k: types.SimpleNamespace(open=False),
+    Text=lambda t: t,
+    colors=types.SimpleNamespace(GREEN_400="GREEN", RED_400="RED"),
+    Page=type("Page", (), {}),
+)
+
+with mock.patch.dict(sys.modules, {"flet": dummy_ft}):
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    Main_1 = importlib.import_module("Main_1")
+
+
+def make_dummy_page():
+    page = types.SimpleNamespace()
+    page.update = mock.MagicMock()
+    return page
+
+
+@mock.patch.object(Main_1, "datetime")
+@mock.patch.object(Main_1, "open", new_callable=mock.mock_open)
+@mock.patch.object(Main_1.os.path, "exists", return_value=False)
+@mock.patch.object(Main_1.os, "makedirs")
+def test_create_directory_and_write_file(mock_makedirs, mock_exists, mock_open, mock_datetime):
+    page = make_dummy_page()
+    interrogatorio = {"Sec": {"K": "V", "Ignore": ""}}
+
+    mock_datetime.now.return_value.strftime.return_value = "20230101_000000"
+
+    dummy_ft = types.SimpleNamespace(
+        SnackBar=lambda *a, **k: types.SimpleNamespace(open=False),
+        Text=lambda t: t,
+        colors=types.SimpleNamespace(GREEN_400="GREEN", RED_400="RED"),
+    )
+
+    with mock.patch.object(Main_1, "ft", dummy_ft):
+        Main_1.save_interrogatorio_to_txt(interrogatorio, page)
+
+    mock_exists.assert_called_once_with("dados_interrogatorio")
+    mock_makedirs.assert_called_once_with("dados_interrogatorio")
+    mock_open.assert_called_once_with(
+        "dados_interrogatorio/interrogatorio_mtc_20230101_000000.txt",
+        "w",
+        encoding="utf-8",
+    )
+    handle = mock_open()
+    handle.write.assert_any_call("\nSec\n")
+    handle.write.assert_any_call("=" * 50 + "\n")
+    handle.write.assert_any_call("K: V\n")
+    assert page.snack_bar.open is True
+    page.update.assert_called_once()
+
+
+@mock.patch.object(Main_1, "datetime")
+@mock.patch.object(Main_1, "open", new_callable=mock.mock_open)
+@mock.patch.object(Main_1.os.path, "exists", return_value=True)
+@mock.patch.object(Main_1.os, "makedirs")
+def test_existing_directory_no_makedirs(mock_makedirs, mock_exists, mock_open, mock_datetime):
+    page = make_dummy_page()
+    interrogatorio = {"Sec": {}}
+
+    mock_datetime.now.return_value.strftime.return_value = "20230101_000000"
+
+    dummy_ft = types.SimpleNamespace(
+        SnackBar=lambda *a, **k: types.SimpleNamespace(open=False),
+        Text=lambda t: t,
+        colors=types.SimpleNamespace(GREEN_400="GREEN", RED_400="RED"),
+    )
+
+    with mock.patch.object(Main_1, "ft", dummy_ft):
+        Main_1.save_interrogatorio_to_txt(interrogatorio, page)
+
+    mock_exists.assert_called_once_with("dados_interrogatorio")
+    mock_makedirs.assert_not_called()
+    mock_open.assert_called_once()
+    assert page.snack_bar.open is True
+    page.update.assert_called_once()


### PR DESCRIPTION
## Summary
- refactor save function for easier reuse and add __main__ guard
- add pytest test suite covering directory creation and file writing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68743869f4b8832eabb0255d13068a81